### PR TITLE
hostname naming, fix healthChecks

### DIFF
--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -8,3 +8,4 @@ docker build --rm=true --tag=consul consul
 docker build --rm=true --tag=haproxy haproxy
 docker build --rm=true --tag=openvpn openvpn
 docker build --rm=true --tag=registrator registrator
+docker build --rm=true --tag=dnsmasq dnsmasq

--- a/dnsmasq/Dockerfile
+++ b/dnsmasq/Dockerfile
@@ -5,8 +5,6 @@ MAINTAINER Wojciech Sielski "wsielski@team.mobile.de"
 RUN apt-get update && \
     apt-get install -y dnsmasq dnsutils
 
-VOLUME ["/etc/openvpn"]
-
 WORKDIR /opt
 
 ADD supervisord.conf /etc/supervisor/supervisord.conf

--- a/dnsmasq/supervisord.conf
+++ b/dnsmasq/supervisord.conf
@@ -13,8 +13,8 @@ serverurl=unix:///tmp/supervisor.sock
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
-[program:openvpn]
-command=/usr/sbin/dnsmasq -d -u dnsmasq -r /etc/resolv.conf -7 /etc/dnsmasq.d --server=/consul/%(ENV_MASTER_IP)s#8600 --server=%(ENV_MASTER_IP)s
+[program:dnsmasq]
+command=/usr/sbin/dnsmasq -d -u dnsmasq -r /etc/resolv.conf -7 /etc/dnsmasq.d --server=/consul/%(ENV_MASTER_IP)s#8600 --server=%(ENV_MASTER_IP)s --host-record=%(ENV_MASTER_HOSTNAME)s,%(ENV_MASTER_IP)s
 autorestart=true
 user=root
 stdout_events_enabled = true

--- a/fig.yml.tpl
+++ b/fig.yml.tpl
@@ -1,34 +1,42 @@
 zk:
   image: ${REGISTRY}mesos
   command: /usr/share/zookeeper/bin/zkServer.sh start-foreground
+  ports:
+    - "2181:2181"
+  hostname: $HOSTNAME-zk
   name: zk
 
 master:
+  environment:
+    ZOOKEEPER_HOSTS: "$HOSTNAME:2181"
+    MASTER_HOST: $HOSTNAME
   image: ${REGISTRY}mesos-master
+  dns: $IP
   ports:
     - "5050:5050"
     - "8080:8080"
     - "9001:9001"
-  links:
-    - "zk:zookeeper"
-  hostname: $HOSTNAME
+  hostname: $HOSTNAME-master
   name: mesos-master
 
 slave:
   privileged: true
+  environment:
+    ZOOKEEPER_HOSTS: "$HOSTNAME:2181"
+    MASTER_HOST: $HOSTNAME
   image: ${REGISTRY}mesos-slave
-  links:
-    - "zk:zookeeper"
+  command: "--master=zk://$IP:2181/mesos --containerizers=docker,mesos --executor_registration_timeout=5mins --hostname=$HOSTNAME"
   volumes:
     - "/var/run/docker.sock:/var/run/docker.sock"
     - "/var/lib/docker:/var/lib/docker"
     - "/usr/local/bin/docker:/usr/local/bin/docker"
     - "/sys:/sys"
     - "/tmp/mesos:/tmp/mesos"
+  dns: $IP
   ports:
     - "5051:5051"
     - "9002:9001"
-  hostname: $HOSTNAME
+  hostname: $HOSTNAME-slave
   name: mesos-slave
 
 consul:
@@ -83,7 +91,19 @@ openvpn:
 registrator:
   image: ${REGISTRY}registrator
   name: registrator
-  hostname: $HOSTNAME
+  hostname: $HOSTNAME-registrator
   volumes:
     - "/var/run/docker.sock:/tmp/docker.sock"
   command: consul://$IP:8500
+
+dns:
+  environment:
+    MASTER_IP: $IP
+    MASTER_HOSTNAME: $HOSTNAME
+  ports:
+    - "$IP:53:53"
+    - "$IP:53:53/udp"
+  privileged: true
+  image: dnsmasq
+  name: dnsmasq
+  net: bridge

--- a/mesos-master/Dockerfile
+++ b/mesos-master/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Mark O'Connor <mark@myspotontheweb.com>
 EXPOSE 5050
 EXPOSE 8080
 
-RUN echo "zk://zookeeper:2181/mesos" > /etc/mesos/zk
+RUN rm /etc/mesos/zk
 ADD supervisord.conf /etc/supervisor/supervisord.conf
 
 ENTRYPOINT ["supervisord"]

--- a/mesos-master/supervisord.conf
+++ b/mesos-master/supervisord.conf
@@ -14,14 +14,14 @@ serverurl=unix:///tmp/supervisor.sock
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:mesos-master]
-command=mesos-master --zk=zk://zookeeper:2181/mesos --work_dir=/var/lib/mesos --quorum=1
+command=mesos-master --zk=zk://%(ENV_ZOOKEEPER_HOSTS)s/mesos --work_dir=/var/lib/mesos --quorum=1 --hostname=%(ENV_MASTER_HOST)s
 autorestart=true
 user=root
 stdout_events_enabled = true
 stderr_events_enabled = true
 
 [program:marathon]
-command=marathon
+command=marathon --master zk://%(ENV_ZOOKEEPER_HOSTS)s/mesos --zk zk://%(ENV_ZOOKEEPER_HOSTS)s/marathon --hostname %(ENV_MASTER_HOST)s
 autorestart=true
 user=root
 stdout_events_enabled = true

--- a/mesos-slave/Dockerfile
+++ b/mesos-slave/Dockerfile
@@ -1,12 +1,14 @@
 FROM mesos
 MAINTAINER Wojciech Sielski "wsielski@team.mobile.de"
 
-RUN echo 'docker,mesos' > /etc/mesos-slave/containerizers
-RUN echo '5mins' > /etc/mesos-slave/executor_registration_timeout
+# /etc/mesos-slave settings are /usr/bin/mesos-init-wrapper specific
+#RUN echo 'docker,mesos' > /etc/mesos-slave/containerizers
+#RUN echo '5mins' > /etc/mesos-slave/executor_registration_timeout
+
 RUN echo 'deb http://get.docker.io/ubuntu docker main' > /etc/apt/sources.list.d/docker.list
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv D8576A8BA88D21E9
 RUN apt-get update && apt-get install -y lxc-docker
 
-CMD ["--master=zk://zookeeper:2181/mesos", "--containerizers=docker,mesos"]
+CMD ["--master=zk://zookeeper:2181/mesos", "--containerizers=docker,mesos", "--executor_registration_timeout=5mins"]
 
 ENTRYPOINT ["mesos-slave"]

--- a/optional/build-docker-image.sh
+++ b/optional/build-docker-image.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-docker build --rm=true --tag=dnsmasq dnsmasq

--- a/optional/fig.yml.tpl
+++ b/optional/fig.yml.tpl
@@ -1,7 +1,0 @@
-dns:
-  environment:
-    MASTER_IP: $IP
-  privileged: true
-  image: dnsmasq
-  name: dnsmasq
-  net: host


### PR DESCRIPTION
Due to hostname issues (same hostname in container and host system) marathon was unable to perform healthchecks.
