### PR TITLE
add support for `TCP forwarding`

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,18 @@ $ dig @$CONSUL_IP -p8600  python.service.consul +tcp SRV
 
 remmeber to disable DNS caching in your future services.
 
-## Put service into HAproxy loadbalancer
+## Put service into HAproxy HTTP loadbalancer
 
-In order to put service into loadbalancer (HAproxy), you need to create service with specific consul tag  
-(ENV `SERVICE_TAGS="haproxy"`) in JSON deployment plan (see examples).
+In order to put a service `my_service` into the `HTTP` loadbalancer (HAproxy), you need to add a `consul` tag `haproxy` 
+(ENV `SERVICE_TAGS="haproxy"`) to the JSON deployment plan for `my_service` (see examples). `my_service` is then accessible
+on port `80` via `my_service.service.consul:80` and/or `my_service.service.<my_dc>.consul:80`.
+
+## Put service into HAproxy TCP loadbalancer
+
+In order to put a service `my_service` into the `TCP` loadbalancer (HAproxy), you need to add a `consul` tag `haproxy_tcp` specifying
+the specific `<port>` (ENV `SERVICE_TAGS="haproxy_tcp=<port>"`) to the JSON deployment plan for `my_service`. It is also recommended
+to set the same `<port>` as the `servicePort` in the `docker` part of the JSON deployment plan. `my_service` is then accessible on
+the specific `<port>` on all cluster nodes, e.g., `my_service.service.consul:<port>` and/or `my_service.service.<my_dc>.consul:<port>`.
 
 ## Create A/B test services (AKA canaries services)
 

--- a/infrastructure/template.conf
+++ b/infrastructure/template.conf
@@ -1,24 +1,37 @@
 {{file "haproxy.cfg"}}
 
-{{range services}}{{range $tag, $services := service .Name|byTag}}{{if or (eq $tag "webapp") (eq $tag "haproxy")}}    #{{$service_name := (index $services 0).Name}}{{$service_name}}
+{{range services}}{{range $tag, $services := service .Name|byTag}}{{if or (eq $tag "webapp") (eq $tag "haproxy")}}{{$service_name := (index $services 0).Name}}    # HTTP service: {{$service_name}}
     {{range datacenters}}acl acl_{{$service_name}} hdr(host) -i {{$service_name}}.service.{{.}}.consul{{end}}
     acl acl_{{$service_name}} hdr(host) -i {{$service_name}}.service.consul
     use_backend backend_{{$service_name}} if acl_{{$service_name}}
+
 {{end}}{{end}}{{end}}
 
     acl acl_panteras hdr(host) -i localhost
-    acl acl_panteras hdr(host) 127.0.0.1
+    acl acl_panteras hdr(host)    127.0.0.1
     {{if ne (env "HOSTNAME") ""}}acl acl_panteras hdr(host) -i {{env "HOSTNAME"}}{{end}}
-    {{if ne (env "FQDN") ""}}acl acl_panteras hdr(host) -i {{env "FQDN"}}{{end}}
-    {{if ne (env "HOST_IP")  ""}}acl acl_panteras hdr(host) {{env "HOST_IP" }}{{end}}
+    {{if ne (env "FQDN")     ""}}acl acl_panteras hdr(host) -i {{env "FQDN"}}{{end}}
+    {{if ne (env "HOST_IP")  ""}}acl acl_panteras hdr(host)    {{env "HOST_IP" }}{{end}}
     use_backend backend_panteras if acl_panteras
-    backend backend_panteras
-      errorfile 503 /etc/haproxy/errors/panteras.http
 
-{{range services}}{{range $tag, $services := service .Name|byTag}}{{if or (eq $tag "webapp") (eq $tag "haproxy")}}{{$service_name := (index $services 0).Name}}
-    backend backend_{{$service_name}}{{$key_maxconn := printf "/haproxy/%s/maxconn" $service_name}}
-      balance roundrobin
-      option http-server-close
-{{range $services}}      server {{.Node}}_{{.Port}} {{.Address}}:{{.Port}} maxconn {{if key $key_maxconn}}{{key $key_maxconn}}{{else}}128{{end}} {{range .Tags}}{{if .| regexMatch "weight=([0-9]+)" }} {{.| regexReplaceAll "=" " "}} {{end}}{{end}}
+    backend backend_panteras
+        errorfile 503 /etc/haproxy/errors/panteras.http
+
+
+{{range services}}{{range $tag, $services := service .Name|byTag}}{{if or (eq $tag "webapp") (eq $tag "haproxy")}}{{$service_name := (index $services 0).Name}}# HTTP service: {{$service_name}}
+backend backend_{{$service_name}}{{$key_maxconn := printf "/haproxy/%s/maxconn" $service_name}}
+    balance roundrobin
+    option  http-server-close
+{{range $services}}    server  {{.Node}}_{{.Port}} {{.Address}}:{{.Port}} maxconn {{if key $key_maxconn}}{{key $key_maxconn}}{{else}}128{{end}} {{range .Tags}}{{if .| regexMatch "weight=([0-9]+)" }} {{.| regexReplaceAll "=" " "}} {{end}}{{end}}
+{{end}}
+{{end}}{{end}}{{end}}
+
+{{range services}}{{range $tag, $services := service .Name|byTag}}{{$service := (index $services 0)}}{{range $service.Tags}}{{if .| regexMatch "haproxy_tcp=([0-9]+)" }}{{$tcp_port := .| regexReplaceAll "haproxy_tcp=" ""}}
+# TCP forwarding service: {{$service.Name}}:{{$tcp_port}}
+listen tcp_{{$service.Name}} :{{$tcp_port}}
+    mode    tcp
+    option  tcplog
+    balance roundrobin
+{{range $services}}    server  {{.Node}}_{{.Port}} {{.Address}}:{{.Port}} check{{end}}
 {{end}}
 {{end}}{{end}}{{end}}


### PR DESCRIPTION
This PR adds support for `TCP forwarding` (in contrast to `HTTP proxying`).

A service can specify a `<port>` via the special `consul` tag `haproxy_tcp=<port>` and the `haproxy` template will create corresponding forwarding and loadbalancing rules, e.g., for the service `my_tcp_srv` with `haproxy_tcp=5000` the following additional `haproxy` config is generated:
```
# TCP forwarding service: my_tcp_srv:5000
listen tcp_my_tcp_srv :5000
    mode    tcp
    option  tcplog
    balance roundrobin
    server  node-001_31001 10.50.80.36:31001 check
    server  node-001_31011 10.50.80.36:31011 check
    server  node-002_31015 10.50.80.81:31015 check
```
... and the service will be accessible via `my_tcp_srv.service.consul:5000` from within the cluster.

The service can be scaled and also be deployed several times on the same node.