### PR TITLE
allow to customize the panteras docker image used by docker-compose

### DIFF
--- a/docker-compose.yml.tpl
+++ b/docker-compose.yml.tpl
@@ -1,6 +1,6 @@
 panteras:
   dns:        ${DNS_IP}
-  image:      "${REGISTRY}panteras/paas-in-a-box"
+  image:      ${PANTERAS_DOCKER_IMAGE}
   name:       panteras
   net:        host
   privileged: true

--- a/generate_yml.sh
+++ b/generate_yml.sh
@@ -42,6 +42,10 @@ IP=${IP:-$(dig +short ${HOSTNAME})}
 MASTER=${MASTER:-"true"}
 SLAVE=${SLAVE:-"true"}
 
+# allow to specify a specific docker image or a specific tag of the pass-in-a-box image
+PANTERAS_IMAGE_TAG=${PANTERAS_IMAGE_TAG:-"latest"}
+PANTERAS_DOCKER_IMAGE=${PANTERAS_DOCKER_IMAGE:-${REGISTRY}panteras/paas-in-a-box:${PANTERAS_IMAGE_TAG}}
+
 #COMMON
 START_CONSUL=${START_CONSUL:-"true"}
 #MASTER


### PR DESCRIPTION
You can define either:

1. `PANTERAS_IMAGE_TAG`: (default: `latest`) to define a specific version/tag for the image to be used, or
2. `PANTERAS_DOCKER_IMAGE`: to define a completely customized docker image registry, name, and tag.