### PR TITLE
always take no quote

### DIFF
--- a/docker-compose.yml.tpl
+++ b/docker-compose.yml.tpl
@@ -2,7 +2,7 @@ panteras:
   image:      ${PANTERAS_DOCKER_IMAGE}
   net:        host
   privileged: true
-  restart:    "${PANTERAS_RESTART}"
+  restart:    ${PANTERAS_RESTART}
   ${PORTS}
      ${CONSUL_UI_PORTS} 
      ${MARATHON_PORTS}


### PR DESCRIPTION
I had some trouble restarting PanteraS when restarting a nodes. 
This solved for me when starting with docker-compose 1.4.2
docker-compose [docs](https://docs.docker.com/compose/compose-file/) specify a `restart: always
` without double quotes.