### PR TITLE
fixing typo in Dockerfile for jessie-node6

### DIFF
--- a/frameworks/jessie-node6/Dockerfile
+++ b/frameworks/jessie-node6/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Wojciech Sielski <wsielski@team.mobile.de>
 RUN cd /usr/local/bin/ && curl -O https://raw.githubusercontent.com/eBayClassifiedsGroup/PanteraS/master/frameworks/start.sh
 RUN chmod +x /usr/local/bin/start.sh
 
-ENV IMAGE panteras/jessie-node5
+ENV IMAGE panteras/jessie-node6
 ENV HOME  /
 WORKDIR /
 


### PR DESCRIPTION
of course the image name is not jessie node 5 but jessie node 6
very sorry for typo