### PR TITLE
Fix #255, upgrade haproxy, mesos and marathon

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -15,7 +15,7 @@ ENV GOPATH ${HOME}/go
 
 RUN apt-get update \
     && apt-get install -y \
-       locale \
+       locales \
        apt-transport-https \
        python-pip \
        wget \

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -5,8 +5,6 @@ FROM ubuntu:16.04
 
 MAINTAINER Wojciech Sielski "wsielski@team.mobile.de"
 
-RUN locale-gen en_US.UTF-8
-
 ENV DEBIAN_FRONTEND noninteractive
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
@@ -17,6 +15,7 @@ ENV GOPATH ${HOME}/go
 
 RUN apt-get update \
     && apt-get install -y \
+       locale \
        apt-transport-https \
        python-pip \
        wget \
@@ -48,6 +47,8 @@ ENV FABIO_GO_APP_VERSION          go1.7.5
 ENV NETDATA_APP_VERSION           1.5.0
 
 ENV DOCKER_HOST unix:///tmp/docker.sock
+
+RUN locale-gen en_US.UTF-8
 
 # SupervisorD
 #

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -5,6 +5,12 @@ FROM ubuntu:16.04
 
 MAINTAINER Wojciech Sielski "wsielski@team.mobile.de"
 
+RUN apt-get update \
+    && apt-get install -y \
+      locales
+
+RUN locale-gen en_US.UTF-8
+
 ENV DEBIAN_FRONTEND noninteractive
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
@@ -15,7 +21,6 @@ ENV GOPATH ${HOME}/go
 
 RUN apt-get update \
     && apt-get install -y \
-       locales \
        apt-transport-https \
        python-pip \
        wget \
@@ -37,18 +42,17 @@ ENV SUPERVISORD_APP_VERSION       3.2.3
 ENV DOCKER_APP_VERSION            1.13.1-0~ubuntu-xenial
 ENV CONSUL_APP_VERSION            0.7.5
 ENV CONSUL_TEMPLATE_APP_VERSION   0.18.1
-ENV HAPROXY_APP_VERSION           1.6.11-1ppa1~xenial
-ENV MESOS_APP_VERSION             1.0.1-2.0.94.ubuntu1604
-ENV MARATHON_APP_VERSION          1.3.10-1.0.627.ubuntu1604
+ENV HAPROXY_APP_VERSION           1.6.12-1ppa1~xenial
+ENV MESOS_APP_VERSION             1.2.0-2.0.6
+ENV MARATHON_APP_VERSION          1.4.3-1.0.649.ubuntu1604
 ENV REGISTRATOR_APP_VERSION       v7
 ENV CHRONOS_APP_VERSION           2.4.0-0.1.20151007110204.ubuntu1404
 ENV FABIO_APP_VERSION             1.3.8
 ENV FABIO_GO_APP_VERSION          go1.7.5
-ENV NETDATA_APP_VERSION           1.5.0
+ENV NETDATA_APP_VERSION           1.6.0
 
 ENV DOCKER_HOST unix:///tmp/docker.sock
 
-RUN locale-gen en_US.UTF-8
 
 # SupervisorD
 #


### PR DESCRIPTION
Improvement:

- Fix #255: locales was not installed by default

Upgrade version:

- haproxy: previous version was not on the repository anymore
- mesos
- marathon