### PR TITLE
Remove consul warning

### DIFF
--- a/generate_yml.sh
+++ b/generate_yml.sh
@@ -126,7 +126,7 @@ CONSUL_PARAMS="agent \
  -data-dir=/opt/consul/data \
  -ui \
  -node=${HOSTNAME} \
- -dc=${CONSUL_DC} \
+ -datacenter=${CONSUL_DC} \
  -domain ${CONSUL_DOMAIN} \
  ${CONSUL_MODE} \
  ${CONSUL_HOSTS} \


### PR DESCRIPTION
remove a consul log warning. (visible from http://localhost:9000)

    ==> WARNING: the 'dc' flag has been deprecated. Use 'datacenter' instead